### PR TITLE
Porting TSCH to iotlab-m3

### DIFF
--- a/core/net/mac/tsch/tsch-packet.h
+++ b/core/net/mac/tsch/tsch-packet.h
@@ -36,6 +36,7 @@
 /********** Includes **********/
 
 #include "contiki.h"
+#include "net/packetbuf.h"
 #include "net/mac/tsch/tsch-private.h"
 #include "net/mac/frame802154.h"
 #include "net/mac/frame802154e-ie.h"
@@ -81,7 +82,7 @@ by default, useful in case of duplicate seqno */
 /********** Constants *********/
 
 /* Max TSCH packet lenght */
-#define TSCH_PACKET_MAX_LEN 127
+#define TSCH_PACKET_MAX_LEN MIN(127,PACKETBUF_SIZE)
 
 /********** Functions *********/
 

--- a/examples/ipv6/rpl-tsch/project-conf.h
+++ b/examples/ipv6/rpl-tsch/project-conf.h
@@ -67,6 +67,9 @@
 #define TSCH_CALLBACK_JOINING_NETWORK tsch_rpl_callback_joining_network
 #define TSCH_CALLBACK_LEAVING_NETWORK tsch_rpl_callback_leaving_network
 
+/* Needed for IoT-LAB M3 nodes */
+#undef RF2XX_SOFT_PREPARE
+#define RF2XX_SOFT_PREPARE 0
 /* Needed for cc2420 platforms only */
 /* Disable DCO calibration (uses timerB) */
 #undef DCOSYNCH_CONF_ENABLED

--- a/examples/ipv6/rpl-tsch/project-conf.h
+++ b/examples/ipv6/rpl-tsch/project-conf.h
@@ -70,6 +70,8 @@
 /* Needed for IoT-LAB M3 nodes */
 #undef RF2XX_SOFT_PREPARE
 #define RF2XX_SOFT_PREPARE 0
+#undef RF2XX_WITH_TSCH
+#define RF2XX_WITH_TSCH 1
 /* Needed for cc2420 platforms only */
 /* Disable DCO calibration (uses timerB) */
 #undef DCOSYNCH_CONF_ENABLED

--- a/platform/openlab/contiki-openlab-conf.h
+++ b/platform/openlab/contiki-openlab-conf.h
@@ -99,14 +99,19 @@ typedef unsigned int uip_stats_t;
 /*
  * Network setup for IPv6
  */
+#ifndef NETSTACK_CONF_NETWORK
 #define NETSTACK_CONF_NETWORK       sicslowpan_driver
+#endif
+#ifndef NETSTACK_CONF_MAC
 #define NETSTACK_CONF_MAC           csma_driver
+#endif
+#ifndef NETSTACK_CONF_FRAMER
 #define NETSTACK_CONF_FRAMER        framer_802154
+#endif
 /* NETSTACK_CONF_RDC */
+#ifndef NETSTACK_CONF_RDC
 #define NETSTACK_CONF_RDC           contikimac_driver
-//#define NETSTACK_CONF_RDC           nullrdc_driver
-//#define NETSTACK_CONF_RDC           cxmac_driver
-//#define NETSTACK_CONF_RDC           sicslowmac_driver
+#endif
 
 #define UIP_CONF_ICMP6              1
 #define SICSLOWPAN_CONF_COMPRESSION             SICSLOWPAN_COMPRESSION_HC06

--- a/platform/openlab/contiki-openlab-conf.h
+++ b/platform/openlab/contiki-openlab-conf.h
@@ -60,6 +60,14 @@ typedef int32_t  s32_t;
 /* Prefix for relocation sections in ELF files */
 #define REL_SECT_PREFIX ".rel"
 
+/* Delay between GO signal and SFD
+ * TODO: the current value is only a guess, needs actual measurement */
+#define RADIO_DELAY_BEFORE_TX ((unsigned)US_TO_RTIMERTICKS(182))
+/* Delay between GO signal and start listening
+ * TODO: the current value is only a guess, needs actual measurement */
+#define RADIO_DELAY_BEFORE_RX ((unsigned)US_TO_RTIMERTICKS(150))
+/* Delay between the SFD finishes arriving and it is detected in software */
+#define RADIO_DELAY_BEFORE_DETECT ((unsigned)US_TO_RTIMERTICKS(0))
 
 /* ---------------------------------------- */
 

--- a/platform/openlab/radio-rf2xx.c
+++ b/platform/openlab/radio-rf2xx.c
@@ -261,11 +261,9 @@ rf2xx_wr_transmit(unsigned short transmit_len)
     // Start TX
     rf2xx_slp_tr_set(RF2XX_DEVICE);
 
-    // Wait until the end of the packet
-    while (rf2xx_state == RF_TX)
-    {
-        ;
-    }
+    // Wait until the transmission starts and ends
+    while(!(rf2xx_get_status(RF2XX_DEVICE) == RF2XX_TRX_STATUS__BUSY_TX));
+    while(!((rf2xx_get_status(RF2XX_DEVICE) != RF2XX_TRX_STATUS__BUSY_TX) || (rf2xx_state != RF_TX)));
 
     ret = RADIO_TX_OK;
 

--- a/platform/openlab/radio-rf2xx.c
+++ b/platform/openlab/radio-rf2xx.c
@@ -188,9 +188,6 @@ rf2xx_wr_hard_prepare(const void *payload, unsigned short payload_le, int async)
 	  }
 	} while (reg != RF2XX_TRX_STATUS__PLL_ON);
 
-	// Enable IRQ interrupt
-	rf2xx_irq_enable(RF2XX_DEVICE);
-
 	// Copy the packet to the radio FIFO
 	rf2xx_fifo_write_first(RF2XX_DEVICE, tx_len + 2);
 	if(async) {

--- a/platform/openlab/radio-rf2xx.c
+++ b/platform/openlab/radio-rf2xx.c
@@ -52,9 +52,19 @@ extern rf2xx_t RF2XX_DEVICE;
 #ifndef RF2XX_TX_POWER
 #define RF2XX_TX_POWER  PHY_POWER_3dBm
 #endif
+#ifndef RF2XX_SOFT_PREPARE
+/* The RF2xx has a single FIFO for Tx and Rx.
+ * - When RF2XX_SOFT_PREPARE is set, rf2xx_wr_prepare merely copies the data to be sent to a soft tx_buf.
+ * rf2xx_wr_transmit will copy from tx_buf to the FIFO and then send.
+ * - When RF2XX_SOFT_PREPARE is unset, rf2xx_wr_prepare actually copies to the FIFO, and rf2xx_wr_transmit
+ * only will only trigger the transmission. */
+#define RF2XX_SOFT_PREPARE 1
+#endif
 
 #define RF2XX_MAX_PAYLOAD 125
+#if RF2XX_SOFT_PREPARE
 static uint8_t tx_buf[RF2XX_MAX_PAYLOAD];
+#endif /* RF2XX_SOFT_PREPARE */
 static uint8_t tx_len;
 
 enum rf2xx_state
@@ -112,6 +122,82 @@ rf2xx_wr_init(void)
 
 /*---------------------------------------------------------------------------*/
 
+/** Copy packet to be sent to the fifo */
+static int
+rf2xx_wr_hard_prepare(const void *payload, unsigned short payload_le, int async)
+{
+	uint8_t reg;
+	int flag;
+    rtimer_clock_t time;
+
+	// Check state
+	platform_enter_critical();
+	// critical section ensures
+	// no packet reception will be started
+	flag = 0;
+	switch (rf2xx_state)
+	{
+		case RF_LISTEN:
+			flag = 1;
+		case RF_IDLE:
+			rf2xx_state = RF_TX;
+			break;
+		default:
+			platform_exit_critical();
+			return RADIO_TX_COLLISION;
+	}
+	platform_exit_critical();
+
+	if (flag)
+	{
+		idle();
+	}
+
+	// Read IRQ to clear it
+	rf2xx_reg_read(RF2XX_DEVICE, RF2XX_REG__IRQ_STATUS);
+
+	// If radio has external PA, enable DIG3/4
+	if (rf2xx_has_pa(RF2XX_DEVICE))
+	{
+	  // Enable the PA
+	  rf2xx_pa_enable(RF2XX_DEVICE);
+
+	  // Activate DIG3/4 pins
+	  reg = rf2xx_reg_read(RF2XX_DEVICE, RF2XX_REG__TRX_CTRL_1);
+	  reg |= RF2XX_TRX_CTRL_1_MASK__PA_EXT_EN;
+	  rf2xx_reg_write(RF2XX_DEVICE, RF2XX_REG__TRX_CTRL_1, reg);
+	}
+
+	// Wait until PLL ON state
+	time = RTIMER_NOW() + RTIMER_SECOND / 1000;
+	do
+	{
+	  reg = rf2xx_get_status(RF2XX_DEVICE);
+
+	  // Check for block
+	  if (RTIMER_CLOCK_LT(time, RTIMER_NOW()))
+	  {
+	    log_error("radio-rf2xx: Failed to enter tx");
+	    restart();
+	    return RADIO_TX_ERR;
+	  }
+	} while (reg != RF2XX_TRX_STATUS__PLL_ON);
+
+	// Enable IRQ interrupt
+	rf2xx_irq_enable(RF2XX_DEVICE);
+
+	// Copy the packet to the radio FIFO
+	rf2xx_fifo_write_first(RF2XX_DEVICE, tx_len + 2);
+	if(async) {
+	  rf2xx_fifo_write_remaining_async(RF2XX_DEVICE, payload,
+	      tx_len, NULL, NULL);
+	} else {
+	  rf2xx_fifo_write_remaining(RF2XX_DEVICE, payload,
+	      tx_len);
+	}
+	return 0;
+}
+
 /** Prepare the radio with a packet to be sent. */
 static int
 rf2xx_wr_prepare(const void *payload, unsigned short payload_len)
@@ -126,9 +212,14 @@ rf2xx_wr_prepare(const void *payload, unsigned short payload_len)
     }
 
     tx_len = payload_len;
-    memcpy(tx_buf, payload, tx_len);
 
+#if RF2XX_SOFT_PREPARE
+    memcpy(tx_buf, payload, tx_len);
     return 0;
+#else /* RF2XX_SOFT_PREPARE */
+    /* Synchronous copy to the FIFO, return */
+    return rf2xx_wr_hard_prepare(payload, tx_len, 0);
+#endif /* RF2XX_SOFT_PREPARE */
 }
 
 /*---------------------------------------------------------------------------*/
@@ -137,9 +228,8 @@ rf2xx_wr_prepare(const void *payload, unsigned short payload_len)
 static int
 rf2xx_wr_transmit(unsigned short transmit_len)
 {
-    int ret, flag;
-    uint8_t reg;
-    rtimer_clock_t time;
+    int ret;
+
     log_info("radio-rf2xx: rf2xx_wr_transmit %d", transmit_len);
 
     if (tx_len != transmit_len)
@@ -149,28 +239,13 @@ rf2xx_wr_transmit(unsigned short transmit_len)
         return RADIO_TX_ERR;
     }
 
-    // Check state
-    platform_enter_critical();
-    // critical section ensures
-    // no packet reception will be started
-    flag = 0;
-    switch (rf2xx_state)
-    {
-        case RF_LISTEN:
-            flag = 1;
-        case RF_IDLE:
-            rf2xx_state = RF_TX;
-            break;
-        default:
-            platform_exit_critical();
-            return RADIO_TX_COLLISION;
+#if RF2XX_SOFT_PREPARE
+    /* Asynchronous copy to the FIFO and before starting to transmit */
+    ret = rf2xx_wr_hard_prepare(tx_buf, tx_len, 1);
+    if(ret != 0) {
+      return ret;
     }
-    platform_exit_critical();
-
-    if (flag)
-    {
-        idle();
-    }
+#endif /* RF2XX_SOFT_PREPARE */
 
 #ifdef RF2XX_LEDS_ON
     if (transmit_len > 10)
@@ -179,44 +254,8 @@ rf2xx_wr_transmit(unsigned short transmit_len)
     }
 #endif
 
-    // Read IRQ to clear it
-    rf2xx_reg_read(RF2XX_DEVICE, RF2XX_REG__IRQ_STATUS);
-
-    // If radio has external PA, enable DIG3/4
-    if (rf2xx_has_pa(RF2XX_DEVICE))
-    {
-        // Enable the PA
-        rf2xx_pa_enable(RF2XX_DEVICE);
-
-        // Activate DIG3/4 pins
-        reg = rf2xx_reg_read(RF2XX_DEVICE, RF2XX_REG__TRX_CTRL_1);
-        reg |= RF2XX_TRX_CTRL_1_MASK__PA_EXT_EN;
-        rf2xx_reg_write(RF2XX_DEVICE, RF2XX_REG__TRX_CTRL_1, reg);
-    }
-
-    // Wait until PLL ON state
-    time = RTIMER_NOW() + RTIMER_SECOND / 1000;
-    do
-    {
-        reg = rf2xx_get_status(RF2XX_DEVICE);
-
-        // Check for block
-        if (RTIMER_CLOCK_LT(time, RTIMER_NOW()))
-        {
-            log_error("radio-rf2xx: Failed to enter tx");
-            restart();
-            return RADIO_TX_ERR;
-        }
-    } while (reg != RF2XX_TRX_STATUS__PLL_ON);
-
     // Enable IRQ interrupt
     rf2xx_irq_enable(RF2XX_DEVICE);
-
-    // Copy the packet to the radio FIFO
-    rf2xx_fifo_write_first(RF2XX_DEVICE, tx_len + 2);
-    rf2xx_fifo_write_remaining_async(RF2XX_DEVICE, tx_buf,
-            tx_len, NULL, NULL);
-
     // Start TX
     rf2xx_slp_tr_set(RF2XX_DEVICE);
 

--- a/platform/openlab/radio-rf2xx.c
+++ b/platform/openlab/radio-rf2xx.c
@@ -82,6 +82,11 @@ static volatile enum rf2xx_state rf2xx_state;
 static volatile int rf2xx_on;
 static volatile int cca_pending;
 
+/* Are we currently in poll mode? */
+static uint8_t volatile poll_mode = 0;
+/* SFD timestamp of last incoming packet */
+static rtimer_clock_t sfd_start_time;
+
 static int read(uint8_t *buf, uint8_t buf_len);
 static void listen(void);
 static void idle(void);
@@ -265,7 +270,7 @@ rf2xx_wr_transmit(unsigned short transmit_len)
         ;
     }
 
-    ret = (rf2xx_state == RF_TX_DONE) ? RADIO_TX_OK : RADIO_TX_ERR;
+    ret = RADIO_TX_OK;
 
 #ifdef RF2XX_LEDS_ON
     leds_off(LEDS_RED);
@@ -300,7 +305,7 @@ rf2xx_wr_read(void *buf, unsigned short buf_len)
 
     // Is there a packet pending
     platform_enter_critical();
-    if (rf2xx_state != RF_RX_DONE)
+    if (rf2xx_wr_pending_packet() == 0)
     {
         platform_exit_critical();
         return 0;
@@ -373,7 +378,7 @@ rf2xx_wr_channel_clear(void)
 static int
 rf2xx_wr_receiving_packet(void)
 {
-    return (rf2xx_state == RF_RX) ? 1 : 0;
+  return (rf2xx_state == RF_RX) || rf2xx_get_status(RF2XX_DEVICE) == RF2XX_TRX_STATUS__BUSY_RX;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -382,7 +387,11 @@ rf2xx_wr_receiving_packet(void)
 static int
 rf2xx_wr_pending_packet(void)
 {
-    return (rf2xx_state == RF_RX_DONE) ? 1 : 0;
+  if(rf2xx_reg_read(RF2XX_DEVICE, RF2XX_REG__IRQ_STATUS) & RF2XX_IRQ_STATUS_MASK__TRX_END) {
+    return 1;
+  } else {
+    return rf2xx_state == RF_RX_DONE;
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -443,6 +452,22 @@ rf2xx_wr_off(void)
 }
 
 /*---------------------------------------------------------------------------*/
+/* Enable or disable poll mode */
+static void
+set_poll_mode(uint8_t enable)
+{
+  poll_mode = enable;
+}
+
+static void
+set_channel(uint8_t channel)
+{
+  uint8_t reg = RF2XX_PHY_CC_CCA_DEFAULT__CCA_MODE |
+        (channel & RF2XX_PHY_CC_CCA_MASK__CHANNEL);
+  rf2xx_reg_write(RF2XX_DEVICE, RF2XX_REG__PHY_CC_CCA, reg);
+}
+
+/*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 const struct radio_driver rf2xx_driver =
@@ -470,7 +495,7 @@ PROCESS_THREAD(rf2xx_process, ev, data)
     {
         static int len;
         static int flag;
-        PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
+        PROCESS_YIELD_UNTIL(!poll_mode && ev == PROCESS_EVENT_POLL);
 
         /*
          * at this point, we may be in any state
@@ -650,11 +675,13 @@ static void reset(void)
     reg = RF2XX_PHY_CC_CCA_DEFAULT__CCA_MODE |
         (RF2XX_CHANNEL & RF2XX_PHY_CC_CCA_MASK__CHANNEL);
     rf2xx_reg_write(RF2XX_DEVICE, RF2XX_REG__PHY_CC_CCA, reg);
+    set_channel(RF2XX_CHANNEL);
 
     // Set IRQ to TRX END/RX_START/CCA_DONE
     rf2xx_reg_write(RF2XX_DEVICE, RF2XX_REG__IRQ_MASK,
             RF2XX_IRQ_STATUS_MASK__TRX_END |
             RF2XX_IRQ_STATUS_MASK__RX_START);
+    set_poll_mode(poll_mode);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -801,6 +828,7 @@ static void irq_handler(handler_arg_t arg)
     if (reg & RF2XX_IRQ_STATUS_MASK__RX_START && state == RF_LISTEN)
     {
         rf2xx_state = state = RF_RX;
+        sfd_start_time = RTIMER_NOW();
     }
 
     // rx/tx end
@@ -816,7 +844,11 @@ static void irq_handler(handler_arg_t arg)
                 rf2xx_state = state = RF_RX_DONE;
                 // we do not want to start a 2nd RX
                 rf2xx_set_state(RF2XX_DEVICE, RF2XX_TRX_STATE__PLL_ON);
-                process_poll(&rf2xx_process);
+                if(!poll_mode) {
+                  /* In poll mode, do not wakeup the process. Rather, the upper layer will poll
+                   * for incoming packets */
+                  process_poll(&rf2xx_process);
+                }
                 break;
         }
     }

--- a/platform/openlab/radio-rf2xx.c
+++ b/platform/openlab/radio-rf2xx.c
@@ -467,6 +467,91 @@ set_channel(uint8_t channel)
   rf2xx_reg_write(RF2XX_DEVICE, RF2XX_REG__PHY_CC_CCA, reg);
 }
 
+static uint8_t
+get_channel()
+{
+  uint8_t reg = rf2xx_reg_read(RF2XX_DEVICE, RF2XX_REG__PHY_CC_CCA);
+  return reg & RF2XX_PHY_CC_CCA_MASK__CHANNEL;
+}
+
+static radio_result_t
+get_value(radio_param_t param, radio_value_t *value)
+{
+  int v;
+
+  if(!value) {
+    return RADIO_RESULT_INVALID_VALUE;
+  }
+  switch(param) {
+  case RADIO_PARAM_RX_MODE:
+    *value = 0;
+    /* No frame filtering, no autoack */
+    if(!poll_mode) {
+      *value |= RADIO_RX_MODE_POLL_MODE;
+    }
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_TX_MODE:
+      *value = 0; /* Mode is always 0 (send-on-cca not supported yet) */
+      return RADIO_RESULT_OK;
+  case RADIO_PARAM_CHANNEL:
+    *value = get_channel();
+    return RADIO_RESULT_OK;
+  default:
+    return RADIO_RESULT_NOT_SUPPORTED;
+  }
+}
+
+static radio_result_t
+set_value(radio_param_t param, radio_value_t value)
+{
+  switch(param) {
+  case RADIO_PARAM_RX_MODE:
+    if(value & ~(RADIO_RX_MODE_ADDRESS_FILTER |
+        RADIO_RX_MODE_AUTOACK | RADIO_RX_MODE_POLL_MODE)) {
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    if(value & RADIO_RX_MODE_ADDRESS_FILTER) {
+      /* Frame filtering not supported yet */
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    if(value & RADIO_RX_MODE_AUTOACK) {
+      /* Autoack not supported yet */
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    set_poll_mode((value & RADIO_RX_MODE_POLL_MODE) != 0);
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_TX_MODE:
+    if(value != 0) { /* We support only mode 0 (send-on-cca not supported yet) */
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_CHANNEL:
+    if(value < 11 || value > 26) {
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    set_channel(value);
+    return RADIO_RESULT_OK;
+  default:
+    return RADIO_RESULT_NOT_SUPPORTED;
+  }
+}
+
+static radio_result_t
+get_object(radio_param_t param, void *dest, size_t size)
+{
+  if(param == RADIO_PARAM_LAST_PACKET_TIMESTAMP) {
+    *(rtimer_clock_t*)dest = sfd_start_time;
+    return RADIO_RESULT_OK;
+  }
+  return RADIO_RESULT_NOT_SUPPORTED;
+}
+
+static radio_result_t
+set_object(radio_param_t param, const void *src, size_t size)
+{
+  return RADIO_RESULT_NOT_SUPPORTED;
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -482,6 +567,10 @@ const struct radio_driver rf2xx_driver =
     .pending_packet   = rf2xx_wr_pending_packet,
     .on               = rf2xx_wr_on,
     .off              = rf2xx_wr_off,
+    .get_value        = get_value,
+    .set_value        = set_value,
+    .get_object       = get_object,
+    .set_object       = set_object,
  };
 
 /*---------------------------------------------------------------------------*/

--- a/platform/openlab/rtimer-arch.h
+++ b/platform/openlab/rtimer-arch.h
@@ -32,6 +32,20 @@
 
 #define RTIMER_ARCH_SECOND (SOFT_TIMER_FREQUENCY)
 
+/* Do the math in 32bits to save precision.
+ * Round to nearest integer rather than truncate. */
+#define US_TO_RTIMERTICKS(US)  ((US) >= 0 ?                        \
+                               (((int32_t)(US) * (RTIMER_ARCH_SECOND) + 500000) / 1000000L) :      \
+                               ((int32_t)(US) * (RTIMER_ARCH_SECOND) - 500000) / 1000000L)
+
+#define RTIMERTICKS_TO_US(T)   ((T) >= 0 ?                     \
+                               (((int32_t)(T) * 1000000L + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)) : \
+                               ((int32_t)(T) * 1000000L - ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND))
+
+/* A 64-bit version because the 32-bit one cannot handle T >= 4295 ticks.
+   Intended only for positive values of T. */
+#define RTIMERTICKS_TO_US_64(T)  ((uint32_t)(((uint64_t)(T) * 1000000 + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)))
+
 /*
  * Contiki support functions
  */


### PR DESCRIPTION
Implements missing radio features on the M3 required for running TSCH. Tested on two nodes on a table, not in IoT-Lab. The patch is far from perfect, there are a few modifications in the driver that I'm not happy with, comments are welcome.

A few modifs are also required in openlab, see https://github.com/iot-lab/openlab/pull/5